### PR TITLE
Namespaces viejos lachi

### DIFF
--- a/src/SchoolManagementSystem.API/Controllers/CrudController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 using Microsoft.EntityFrameworkCore; 
 using AutoMapper;
 

--- a/src/SchoolManagementSystem.API/Controllers/CrudController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudController.cs
@@ -42,7 +42,10 @@ public class CrudController<TEntity, TDTO> : Controller where TEntity :  Entity 
         
         var entity = entities
             .FirstOrDefault(c => Equals(c.Id, id));
-        
+        if (entity == null)
+        {
+            return NotFound(id);
+        }        
         return Ok(entity);
     }
 
@@ -64,7 +67,7 @@ public class CrudController<TEntity, TDTO> : Controller where TEntity :  Entity 
         var entity = entities.FirstOrDefault(c => Equals(c.Id, dto_model.Id));
 
         if(entity == null)
-            throw new NotImplementedException();
+            return NotFound(dto_model);
         
         _mapperToDto.Map(dto_model,entity);
         _service.Update(entity);
@@ -82,7 +85,7 @@ public class CrudController<TEntity, TDTO> : Controller where TEntity :  Entity 
         var entity = entities.FirstOrDefault(c => Equals(c.Id, id));
         
         if(entity == null)
-            throw new NotImplementedException();
+            return NotFound(id);
         
         _service.Remove(entity);
         _service.CommitAsync();

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/BasicMeansController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/BasicMeansController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;
 

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/ClassroomsController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/ClassroomsController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;
 

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/CourseGroupsController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/CourseGroupsController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
 using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/CoursesController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/CoursesController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
 using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/ExpensesController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/ExpensesController.cs
@@ -3,8 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
-using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/PositionsController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/PositionsController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
 using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/ResourcesController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/ResourcesController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
 using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/StudentsController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/StudentsController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
 using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/TeachersController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/TeachersController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
 using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/TuitorsController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/TuitorsController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
 using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;

--- a/src/SchoolManagementSystem.API/Controllers/CrudEntities/WorkersController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/CrudEntities/WorkersController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using SchoolManagementSystem.API.Dtos;
 using SchoolManagementSystem.API.Mappers;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
 using SchoolManagementSystem.Domain.Services;
 using AutoMapper;
 using SchoolManagementSystem.API.Controllers;

--- a/src/SchoolManagementSystem.API/Startup.cs
+++ b/src/SchoolManagementSystem.API/Startup.cs
@@ -1,11 +1,11 @@
 ﻿using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
-using SchoolManagementSystem.Application.Services_Implementations.Entities;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Domain.Services;
+using SchoolManagementSystem.Application.Services_Implementations;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Infrastructure.Repositories.Entities;
+using SchoolManagementSystem.Infrastructure.Repositories;
 using System.Text.Json.Serialization;
 using Microsoft.OpenApi.Models;
 using SchoolManagementSystem.API.Dtos;

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IBasicMeanRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IBasicMeanRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface IBasicMeanRepository : IRepository<BasicMean>
 {

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IClassroomRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IClassroomRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface IClassroomRepository : IRepository<Classroom>
 {

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/ICourseGroupRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/ICourseGroupRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface ICourseGroupRepository : IRepository<CourseGroup>
 {

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/ICourseRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/ICourseRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface ICourseRepository : IRepository<Course>
 {

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IExpenseRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IExpenseRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface IExpenseRepository : IRepository<Expense>
 {

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IPositionRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IPositionRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface IPositionRepository : IRepository<Position>
 {

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IResourceRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IResourceRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface IResourceRepository : IRepository<Resource>
 {

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IStudentRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IStudentRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface IStudentRepository : IRepository<Student>
 {

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/ITeacherRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/ITeacherRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface ITeacherRepository : IRepository<Teacher>
 {

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/ITuitorRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/ITuitorRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface ITuitorRepository : IRepository<Tuitor>
 {

--- a/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IWorkerRepository.cs
+++ b/src/SchoolManagementSystem.Application/Repositories_Interfaces/Entities/IWorkerRepository.cs
@@ -2,7 +2,7 @@
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Domain.Entities;
 
-namespace SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+namespace SchoolManagementSystem.Application.Repositories_Interfaces;
 
 public interface IWorkerRepository : IRepository<Worker>
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/BaseService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/BaseService.cs
@@ -1,8 +1,8 @@
 
 using SchoolManagementSystem.Domain.Interfaces;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class BaseService<TEntity> : IService<TEntity> where TEntity : class
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/BasicMeanService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/BasicMeanService.cs
@@ -1,10 +1,10 @@
 
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
-using SchoolManagementSystem.Application.Services_Implementations.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
+using SchoolManagementSystem.Application.Services_Implementations;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class BasicMeanService : BaseService<BasicMean>, IBasicMeanService
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/ClassroomService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/ClassroomService.cs
@@ -1,9 +1,9 @@
 
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class ClassroomService : BaseService<Classroom>, IClassroomService
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/CourseGroupService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/CourseGroupService.cs
@@ -1,10 +1,10 @@
 
 using Microsoft.EntityFrameworkCore;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class CourseGroupService : BaseService<CourseGroup>, ICourseGroupService
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/CourseService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/CourseService.cs
@@ -1,10 +1,10 @@
 
 using Microsoft.EntityFrameworkCore;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class CourseService : BaseService<Course>, ICourseService
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/ExpenseService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/ExpenseService.cs
@@ -1,10 +1,10 @@
 
 using Microsoft.EntityFrameworkCore;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class ExpenseService : BaseService<Expense>, IExpenseService
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/PositionService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/PositionService.cs
@@ -1,9 +1,9 @@
 
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class PositionService : BaseService<Position>, IPositionService
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/ResourceService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/ResourceService.cs
@@ -1,10 +1,10 @@
 
 using Microsoft.EntityFrameworkCore;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class ResourceService : BaseService<Resource>, IResourceService
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/StudentService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/StudentService.cs
@@ -1,10 +1,10 @@
 
 using Microsoft.EntityFrameworkCore;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class StudentService : BaseService<Student>, IStudentService
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/TeacherService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/TeacherService.cs
@@ -1,10 +1,10 @@
 
 using Microsoft.EntityFrameworkCore;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class TeacherService : BaseService<Teacher>, ITeacherService
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/TuitorService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/TuitorService.cs
@@ -1,10 +1,10 @@
 
 using Microsoft.EntityFrameworkCore;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class TuitorService : BaseService<Tuitor>, ITuitorService
 {

--- a/src/SchoolManagementSystem.Application/Services_Implementations/Entities/WorkerService.cs
+++ b/src/SchoolManagementSystem.Application/Services_Implementations/Entities/WorkerService.cs
@@ -1,10 +1,10 @@
 
 using Microsoft.EntityFrameworkCore;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 using SchoolManagementSystem.Domain.Entities;
-using SchoolManagementSystem.Domain.Services.Entities;
+using SchoolManagementSystem.Domain.Services;
 
-namespace SchoolManagementSystem.Application.Services_Implementations.Entities;
+namespace SchoolManagementSystem.Application.Services_Implementations;
 
 public class WorkerService : BaseService<Worker>, IWorkerService
 {

--- a/src/SchoolManagementSystem.Domain/Interfaces/IRepository.cs
+++ b/src/SchoolManagementSystem.Domain/Interfaces/IRepository.cs
@@ -1,15 +1,8 @@
 
 namespace SchoolManagementSystem.Domain.Interfaces;
 
-public interface IRepository<TEntity> where TEntity : class
+public interface IRepository<TEntity> : IRecordRepository<TEntity> where TEntity : class
 {
-    IObjectContext Context {get; }
-
-    IQueryable<TEntity> Query();
-    void Add(TEntity entity);
     void Update(TEntity entity);
     void Remove(TEntity entity);
-    // void SaveAsync();
-    void Commit();
-    Task CommitAsync();
 }

--- a/src/SchoolManagementSystem.Domain/Services/Entities/IBasicMeanService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/IBasicMeanService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface IBasicMeanService : IService<BasicMean>
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/IClassroomService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/IClassroomService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface IClassroomService : IService<Classroom>
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/ICourseGroupService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/ICourseGroupService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface ICourseGroupService : IService<CourseGroup>
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/ICourseService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/ICourseService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface ICourseService : IService<Course>
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/IExpenseService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/IExpenseService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface IExpenseService : IService<Expense>
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/IPositionService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/IPositionService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface IPositionService : IService<Position>
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/IResourseService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/IResourseService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface IResourceService : IService<Resource>
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/IService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/IService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface IService<TEntity> where TEntity : class
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/IStudentService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/IStudentService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface IStudentService : IService<Student>
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/ITeacherService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/ITeacherService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface ITeacherService : IService<Teacher>
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/ITuitorService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/ITuitorService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface ITuitorService : IService<Tuitor>
 {

--- a/src/SchoolManagementSystem.Domain/Services/Entities/IWorkerService.cs
+++ b/src/SchoolManagementSystem.Domain/Services/Entities/IWorkerService.cs
@@ -1,7 +1,7 @@
 using SchoolManagementSystem.Domain.Entities;
 
 
-namespace SchoolManagementSystem.Domain.Services.Entities;
+namespace SchoolManagementSystem.Domain.Services;
 
 public interface IWorkerService : IService<Worker>
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/BasicMeanRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/BasicMeanRepository.cs
@@ -1,9 +1,9 @@
 ﻿using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class BasicMeanRepository : CrudRepository<BasicMean>, IBasicMeanRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/ClassroomRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/ClassroomRepository.cs
@@ -3,10 +3,9 @@ using Microsoft.EntityFrameworkCore;
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Application.Repositories_Interfaces;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
 // using SchoolManagementSystem.Infrastructure.Data;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class ClassroomRepository : CrudRepository<Classroom>, IClassroomRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/CourseGroupRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/CourseGroupRepository.cs
@@ -1,9 +1,9 @@
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class CourseGroupRepository : CrudRepository<CourseGroup>, ICourseGroupRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/CourseRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/CourseRepository.cs
@@ -1,9 +1,9 @@
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class CourseRepository : CrudRepository<Course>, ICourseRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/CrudRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/CrudRepository.cs
@@ -1,6 +1,6 @@
 using SchoolManagementSystem.Domain.Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities
+namespace SchoolManagementSystem.Infrastructure.Repositories
 {
     public class CrudRepository<TEntity> : IRepository<TEntity> where TEntity : class
     {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/ExpenseRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/ExpenseRepository.cs
@@ -1,9 +1,9 @@
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class ExpenseRepository : CrudRepository<Expense>, IExpenseRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/PositionRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/PositionRepository.cs
@@ -1,9 +1,9 @@
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class PositionRepository : CrudRepository<Position>, IPositionRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/ResourceRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/ResourceRepository.cs
@@ -1,9 +1,9 @@
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class ResourceRepository : CrudRepository<Resource>, IResourceRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/StudentRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/StudentRepository.cs
@@ -1,9 +1,9 @@
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class StudentRepository : CrudRepository<Student>, IStudentRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/TeacherRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/TeacherRepository.cs
@@ -1,9 +1,9 @@
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class TeacherRepository : CrudRepository<Teacher>, ITeacherRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/TuitorRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/TuitorRepository.cs
@@ -1,9 +1,9 @@
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class TuitorRepository : CrudRepository<Tuitor>, ITuitorRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/WorkerRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Entities/WorkerRepository.cs
@@ -1,9 +1,9 @@
 using SchoolManagementSystem.Domain.Entities;
 using SchoolManagementSystem.Domain.Interfaces;
 using SchoolManagementSystem.Infrastructure.Data;
-using SchoolManagementSystem.Application.Repositories_Interfaces.Entities;
+using SchoolManagementSystem.Application.Repositories_Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Entities;
+namespace SchoolManagementSystem.Infrastructure.Repositories;
 
 public class WorkerRepository : CrudRepository<Worker>, IWorkerRepository
 {

--- a/src/SchoolManagementSystem.Infrastructure/Repositories/Records/RecordRepository.cs
+++ b/src/SchoolManagementSystem.Infrastructure/Repositories/Records/RecordRepository.cs
@@ -1,6 +1,6 @@
 ﻿using SchoolManagementSystem.Domain.Interfaces;
 
-namespace SchoolManagementSystem.Infrastructure.Repositories.Records
+namespace SchoolManagementSystem.Infrastructure.Repositories
 {
     public class RecordRepository<TEntity> : IRecordRepository<TEntity> where TEntity : class
     {


### PR DESCRIPTION
Se volvió a cambiar la separación de los namespace cambiados en el anterior merge pull request (#15 ) pero manteniendo la división por carpetas.
Ahora se devuelve una respuesta HTTP 404 NotFound para las operaciones inválidas con métodos GET, PUT y DELETE de los controladores genéricos
IRepository ahora es IRecordRepository