### PR TITLE
Fix notification lachi

### DIFF
--- a/src/SchoolManagementSystem.API/Controllers/DebtorsController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/DebtorsController.cs
@@ -33,23 +33,31 @@ public class DebtorsController : Controller
         List<DebtorDto> debtors = new List<DebtorDto>();
         foreach (Student student in _servicePayment.GetStudentRepo().Query())
         {
-            foreach(var payment in GroupCurseNoPaid(_servicePayment,student.Id).Where(s => DateTime.Now.Date > s.DatePaid.Date))
-            {
-                debtors.Add(new DebtorDto
-                {
-                    GroupId = payment.GroupId,
-                    GroupName = payment.GroupName,
-                    IDCardNo = student.IDCardNo,
-                    StudentId = student.Id,
-                    StudentName = student.Name,
-                    StudentLastName = student.LastName,
-                    Debt = payment.CoursePrice,
-                    Dealy = (DateTime.Now.Date - payment.DatePaid).Days
-                });
-            }
+            var a = from debt in GroupCurseNoPaid(_servicePayment, student.Id)
+                    where DateTime.Now.Date > debt.DatePaid.Date
+                    group debt by debt.StudentId into g
+                    select new DebtorDto
+                    {
+                        GroupId = g.First().GroupId,
+                        GroupName = g.First().GroupName,
+                        IDCardNo = student.IDCardNo,
+                        StudentId = student.Id,
+                        StudentName = student.Name,
+                        StudentLastName = student.LastName,
+                        Debt = g.Sum(s => s.CoursePrice),
+                        Dealy = (DateTime.Now.Date - g.Min(s => s.DatePaid).Date).Days
+                    };
+            debtors.AddRange(a);
         }
         return Ok(debtors);        
     }
+
+    [HttpGet("{id}")]
+    public IActionResult GetDebtById(string id)
+    {
+        return Ok(GroupCurseNoPaid(_servicePayment, id).ToList());
+    }
+
 
     public static IQueryable<StudentGroupPaymentDto> GroupCurseNoPaid(IDoStudentPaymentService servicePayment, string studentId) 
     {

--- a/src/SchoolManagementSystem.API/Controllers/DebtorsNotificationController.cs
+++ b/src/SchoolManagementSystem.API/Controllers/DebtorsNotificationController.cs
@@ -32,9 +32,9 @@ public class DebtorsNotificationController : Controller
             return NotFound();
         var a = new
         {
-            Title = "There are some debtors.",
-            Descrpition = $"There are {DebtorsStaticClass.DebtorsAmount} students that did not have paid some courses.",
-            Type = "Warning"
+            Title = "Hay deudores.",
+            Descrpition = $"Hay {DebtorsStaticClass.DebtorsAmount} alumnos que no han pagado algunos cursos.",
+            Type = "warning"
         };
         DebtorsStaticClass.DebtorsAmount = 0;
         return Ok (

--- a/src/SchoolManagementSystem.Presentation/src/components/NavBar/NavBar.jsx
+++ b/src/SchoolManagementSystem.Presentation/src/components/NavBar/NavBar.jsx
@@ -195,14 +195,15 @@ const NavBar = (props) => {
             itemLayout="horizontal"            
             dataSource={data}
             renderItem={(item) => (
-            <List.Item>                
+            <List.Item>
+                <a href="http://localhost:3000/Debtors">
                 <Alert
                 message={item.title}
                 description={item.descrpition}
                 type="warning"
                 showIcon
-                closable
-                />               
+                />
+                </a>             
             </List.Item>
             )}
         />    

--- a/src/SchoolManagementSystem.Presentation/src/components/NavBar/NavBar.jsx
+++ b/src/SchoolManagementSystem.Presentation/src/components/NavBar/NavBar.jsx
@@ -140,11 +140,13 @@ const NavBar = (props) => {
     
     return (
         <nav>
-            <img
-                className="navb_left"
-                src={Logo}
-                alt="Logo y nombre D'Clase"
-                />
+            <a href="http://localhost:3000/Home">
+                <img
+                    className="navb_left"
+                    src={Logo}
+                    alt="Logo y nombre D'Clase"                
+                    />
+            </a>
 
                 <a onClick={showDrawerFAQ}>
                     <img


### PR DESCRIPTION
- La notificación de deudores no se cierra ahora. Siempre se mostrará en la lista de notificaciones hasta que no haya deudores
- La tabla de deudores ahora se muestra agrupada por estudiantes (y no por deuda), mostrando el mayor retraso, y la deuda acumulada. Faltaría en el visual quitar la columna de grupos y cursos por deuda, para esa tabla general, ya  que no tienen sentido ahora.
- Se agregó un nuevo EndPoint para saber las deudas de un solo estudiante segun su id. El link es mediante: http://localhost:5001/api/Debtors/{id} . Faltaría agregar esta tabla en el visual de los detalles del estudiante
- Ahora desde el icono de "D'Clase" arriba a la izquierda, se puede retroceder a la página Home